### PR TITLE
Travis OS X builds don't work with modern Xcode #438

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,16 +21,21 @@ matrix:
     - os: linux
       compiler: gcc
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode9.2
       compiler: clang
 
 before_script:
   - export CFLAGS="-Wall -Wextra -Werror"
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap PX4/homebrew-px4; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libusb fftw gcc-arm-none-eabi dfu-util; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade libusb openssl; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask uninstall oclint; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew uninstall python; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew link openssl --force; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libusb fftw gcc-arm-none-eabi dfu-util python@2; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=/usr/local/bin:$PATH; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget -O gcc-arm-none-eabi.tar.bz2 https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xf gcc-arm-none-eabi.tar.bz2; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=$PATH:$PWD/gcc-arm-none-eabi-6-2017-q2-update/bin; fi


### PR DESCRIPTION
Firmware builds are failing on OS X Travis builds because Xcode 8.3 doesn't include the pip tool. It is replaced by pip2 and pip3. Using pip2 installs the packages but it is later not found by the Python process used to build libopencm3.

See log here: https://travis-ci.org/dominicgs/hackrf/jobs/312689327#L1083

It would be great to use a more up to date Xcode, default is 8.3, but 9.2 is also now available.